### PR TITLE
feat: Add support for Customer Managed policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ module "sso" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.23 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30 |
 
 ## Modules
 
@@ -82,6 +82,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_ssoadmin_account_assignment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
+| [aws_ssoadmin_customer_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_customer_managed_policy_attachment) | resource |
 | [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
 | [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
 | [aws_ssoadmin_permission_set_inline_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -6,6 +6,7 @@ Before this example can be used, please ensure that the following pre-requisites
 - Enable AWS SSO. [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/step1.html).
 - Create AWS SSO entities (Users and Groups). [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/addusers.html).
 - Ensure that Terraform is using a role with permissions required for AWS SSO management. [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/iam-auth-access-using-id-policies.html#requiredpermissionsconsole).
+- If using Customer Managed Policies in permission sets, please make sure that policy exists (pre-created) in target AWS account.
 
 ## Diagram
 ![Alt text](aws_sso_diagram.png?raw=true "Title")
@@ -16,19 +17,19 @@ Before this example can be used, please ensure that the following pre-requisites
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.23 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sso"></a> [sso](#module\_sso) | avlcloudtechnologies/sso/aws | n/a |
+| <a name="module_sso"></a> [sso](#module\_sso) | avlcloudtechnologies/sso/aws |  |
 
 ## Resources
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.27"
+      version = ">= 4.30"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.27"
+      version = ">= 4.30"
     }
   }
 }


### PR DESCRIPTION
## Description
* closes #7 
* Add optional parameter customer_managed_policies which can be used to add Customer Managed policies https://aws.amazon.com/about-aws/whats-new/2022/07/aws-single-sign-on-aws-sso-aws-identity-access-management-iam-customer-managed-policies-cmps/
* Changes to "complete" example, simplifies active account filtering

## Breaking Changes
* Need to bump AWS provider version to ">= 4.30" to support Customer Managed policies

## Testing
* Tested by deploying.