### PR TITLE
chore: Update deprecated identitystore filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module handles creation of AWS SSO permission sets and assignment to AWS SS
 Before this module can be used, please ensure that the following pre-requisites are met:
 - Enable AWS Organizations and add AWS Accounts you want to be managed by SSO. [Documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_tutorials_basic.html)
 - Enable AWS SSO. [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/step1.html).
-- Create AWS SSO entities (Users and Groups). [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/addusers.html).
+- Create AWS SSO entities (Users and Groups) [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/addusers.html) or use identitystore [module](https://github.com/avlcloudtechnologies/terraform-aws-identitystore).
 - Ensure that Terraform is using a role with permissions required for AWS SSO management. [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/iam-auth-access-using-id-policies.html#requiredpermissionsconsole).
 
 ## Usage
@@ -65,13 +65,13 @@ module "sso" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.23 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.34 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -39,18 +39,22 @@ data "aws_ssoadmin_instances" "this" {}
 data "aws_identitystore_group" "this" {
   for_each          = toset(local.groups)
   identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = each.value
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.value
+    }
   }
 }
 
 data "aws_identitystore_user" "this" {
   for_each          = toset(local.users)
   identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
-  filter {
-    attribute_path  = "UserName"
-    attribute_value = each.value
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = each.value
+    }
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30"
+      version = ">= 4.34"
     }
   }
 }


### PR DESCRIPTION
## Description
* Change deprecated filtering syntax in data.aws_identitystore_group and data.aws_identitystore_user https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.34.0. 
* closes #9 

## Breaking Changes
* Bumping required AWS provider to 4.34.0
