### PR TITLE
`alternate_identifier` bugfix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.45.0
     hooks:
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ module "sso" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.23 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -29,7 +29,7 @@ Before this example can be used, please ensure that the following pre-requisites
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sso"></a> [sso](#module\_sso) | avlcloudtechnologies/sso/aws |  |
+| <a name="module_sso"></a> [sso](#module\_sso) | avlcloudtechnologies/sso/aws | n/a |
 
 ## Resources
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -26,7 +26,7 @@ Before this example can be used, please ensure that the following pre-requisites
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sso"></a> [sso](#module\_sso) | avlcloudtechnologies/sso/aws |  |
+| <a name="module_sso"></a> [sso](#module\_sso) | avlcloudtechnologies/sso/aws | n/a |
 
 ## Resources
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.34"
+      version = ">= 4.40"
     }
   }
 }


### PR DESCRIPTION
## Description
- aws provider version fix to support `alternate_identifier` for `aws_identitystore_group`
- autoformat of `README.md` and `examples`
- `pre-commit` config fix

the bug was introduced here, where deprecation was applied to both `aws_identitystore_user` and `aws_identitystore_group` data sources ;
https://github.com/avlcloudtechnologies/terraform-aws-sso/pull/11

aws provider version `4.34.0` deprecated `filter` for `data-source/aws_identitystore_user` only
aws provider version `4.40.0` deprecated `filter` for `data-source/aws_identitystore_group`

aws provider docs;
https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4340-october--6-2022
https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4400-november-17-2022

https://registry.terraform.io/providers/hashicorp/aws/4.34.0/docs/data-sources/identitystore_user
https://registry.terraform.io/providers/hashicorp/aws/4.34.0/docs/data-sources/identitystore_group
https://registry.terraform.io/providers/hashicorp/aws/4.40.0/docs/data-sources/identitystore_group

closes #12

## Breaking Changes
* none

## Testing
* local testing