### PR TITLE
feat: Add identitystore group and user data source dependency null resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ module "sso" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -87,6 +88,8 @@ No modules.
 | [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
 | [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
 | [aws_ssoadmin_permission_set_inline_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |
+| [null_resource.group_dependency](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.user_dependency](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_identitystore_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group) | data source |
 | [aws_identitystore_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_user) | data source |
 | [aws_ssoadmin_instances.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
@@ -96,6 +99,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_assignments"></a> [account\_assignments](#input\_account\_assignments) | List of maps containing mapping between user/group, permission set and assigned accounts list. See account\_assignments description in README for more information about map values. | <pre>list(object({<br>    principal_name = string,<br>    principal_type = string,<br>    permission_set = string,<br>    account_ids    = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_identitystore_group_data_source_depends_on"></a> [identitystore\_group\_data\_source\_depends\_on](#input\_identitystore\_group\_data\_source\_depends\_on) | List of parameters that identitystore group data sources depend on, for example new SSO group IDs. | `list(string)` | `[]` | no |
+| <a name="input_identitystore_user_data_source_depends_on"></a> [identitystore\_user\_data\_source\_depends\_on](#input\_identitystore\_user\_data\_source\_depends\_on) | List of parameters that identitystore user data sources depend on, for example new SSO user IDs. | `list(string)` | `[]` | no |
 | <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | Map of maps containing Permission Set names as keys. See permission\_sets description in README for information about map values. | `any` | <pre>{<br>  "AdministratorAccess": {<br>    "description": "Provides full access to AWS services and resources.",<br>    "managed_policies": [<br>      "arn:aws:iam::aws:policy/AdministratorAccess"<br>    ],<br>    "session_duration": "PT2H"<br>  }<br>}</pre> | no |
 
 ## Outputs

--- a/examples/with-dependencies/README.md
+++ b/examples/with-dependencies/README.md
@@ -1,0 +1,47 @@
+# Simple
+Example showing how to create SSO users and groups without module depends_on argument which would re-create all module resources if new AWS account is added. 
+
+## Pre-requisites
+Before this example can be used, please ensure that the following pre-requisites are met:
+- Enable AWS Organizations and add AWS Accounts you want to be managed by SSO. [Documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_tutorials_basic.html)
+- Enable AWS SSO. [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/step1.html).
+- Ensure that Terraform is using a role with permissions required for AWS SSO management. [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/iam-auth-access-using-id-policies.html#requiredpermissionsconsole).
+
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.23 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.27 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.27 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_identitystore"></a> [aws\_identitystore](#module\_aws\_identitystore) | avlcloudtechnologies/identitystore/aws | 0.1.1 |
+| <a name="module_sso"></a> [sso](#module\_sso) | avlcloudtechnologies/sso/aws |  |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_ssoadmin_permission_sets"></a> [aws\_ssoadmin\_permission\_sets](#output\_aws\_ssoadmin\_permission\_sets) | Maps of permission sets with attributes listed in Terraform resource aws\_ssoadmin\_permission\_set documentation. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-dependencies/README.md
+++ b/examples/with-dependencies/README.md
@@ -1,5 +1,5 @@
 # Simple
-Example showing how to create SSO users and groups without module depends_on argument which would re-create all module resources if new AWS account is added. 
+Example showing how to create SSO users and groups in the same state file as `terraform-aws-sso` module resources and without adding `depends_on` argument at the module level. Using null resource, it will only recreate account assignments, when new SSO group is added. It will NOT re-create all module resources, after a new AWS Account is added. 
 
 ## Pre-requisites
 Before this example can be used, please ensure that the following pre-requisites are met:

--- a/examples/with-dependencies/main.tf
+++ b/examples/with-dependencies/main.tf
@@ -1,0 +1,75 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+data "aws_organizations_organization" "this" {}
+
+locals {
+  all_active_accounts_map            = { for account in toset(data.aws_organizations_organization.this.accounts) : account.name => account if account.status == "ACTIVE" }
+  non_management_active_accounts_map = { for account in toset(data.aws_organizations_organization.this.non_master_accounts) : account.name => account if account.status == "ACTIVE" }
+  sso_groups = {
+    management = {
+      description = "Group with Administrator access to all accounts including Management account"
+    },
+    admins = {
+      description = "Group with Administrator access to all accounts excluding Management account"
+    },
+    readonly = {
+      description = "Group for Read only access"
+    }
+  }
+  sso_users = {
+    aurimas = {
+      display_name = "aurimas"
+      given_name   = "Aurimas"
+      family_name  = "Mickevicius"
+      sso_groups   = ["management", "readonly"]
+    },
+    john = {
+      display_name = "john"
+      given_name   = "John"
+      family_name  = "Smith"
+      sso_groups   = ["admins", "readonly"]
+    }
+  }
+}
+
+module "sso" {
+  source = "avlcloudtechnologies/sso/aws"
+
+  permission_sets = {
+    AdministratorAccess = {
+      description      = "Provides full access to AWS services and resources.",
+      session_duration = "PT2H",
+      managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+    },
+    ViewOnlyAccess = {
+      description      = "View resources and basic metadata across all AWS services.",
+      session_duration = "PT2H",
+      managed_policies = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
+    },
+  }
+  account_assignments = [
+    {
+      principal_name = "management"
+      principal_type = "GROUP"
+      permission_set = "AdministratorAccess"
+      account_ids    = [for account in local.all_active_accounts_map : account.id]
+    },
+    {
+      principal_name = "admins"
+      principal_type = "GROUP"
+      permission_set = "AdministratorAccess"
+      account_ids    = [for account in local.non_management_active_accounts_map : account.id]
+    },
+  ]
+  identitystore_group_data_source_depends_on = [for group in module.aws_identitystore.groups : group.group_id]
+}
+
+module "aws_identitystore" {
+  source  = "avlcloudtechnologies/identitystore/aws"
+  version = "0.1.1"
+
+  sso_users  = var.sso_users
+  sso_groups = var.sso_groups
+}

--- a/examples/with-dependencies/main.tf
+++ b/examples/with-dependencies/main.tf
@@ -62,6 +62,12 @@ module "sso" {
       permission_set = "AdministratorAccess"
       account_ids    = [for account in local.non_management_active_accounts_map : account.id]
     },
+    {
+      principal_name = "readonly"
+      principal_type = "GROUP"
+      permission_set = "ViewOnlyAccess"
+      account_ids    = [for account in local.non_management_active_accounts_map : account.id]
+    },
   ]
   identitystore_group_data_source_depends_on = [for group in module.aws_identitystore.groups : group.group_id]
 }

--- a/examples/with-dependencies/outputs.tf
+++ b/examples/with-dependencies/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_ssoadmin_permission_sets" {
+  description = "Maps of permission sets with attributes listed in Terraform resource aws_ssoadmin_permission_set documentation."
+  value       = module.sso.aws_ssoadmin_permission_sets
+}

--- a/examples/with-dependencies/versions.tf
+++ b/examples/with-dependencies/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.12.23"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,18 @@ locals {
   users  = [for assignment in var.account_assignments : assignment.principal_name if assignment.principal_type == "USER"]
 }
 
+resource "null_resource" "group_dependency" {
+  triggers = {
+    dependency_id = join(",", var.identitystore_group_data_source_depends_on)
+  }
+}
+
+resource "null_resource" "user_dependency" {
+  triggers = {
+    dependency_id = join(",", var.identitystore_user_data_source_depends_on)
+  }
+}
+
 data "aws_ssoadmin_instances" "this" {}
 
 data "aws_identitystore_group" "this" {
@@ -45,6 +57,7 @@ data "aws_identitystore_group" "this" {
       attribute_value = each.value
     }
   }
+  depends_on = [null_resource.group_dependency]
 }
 
 data "aws_identitystore_user" "this" {
@@ -56,6 +69,7 @@ data "aws_identitystore_user" "this" {
       attribute_value = each.value
     }
   }
+  depends_on = [null_resource.user_dependency]
 }
 
 resource "aws_ssoadmin_permission_set" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,15 @@ variable "account_assignments" {
 
   default = []
 }
+
+variable "identitystore_group_data_source_depends_on" {
+  description = "List of parameters that identitystore group data sources depend on, for example new SSO group IDs."
+  type        = list(string)
+  default     = []
+}
+
+variable "identitystore_user_data_source_depends_on" {
+  description = "List of parameters that identitystore user data sources depend on, for example new SSO user IDs."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Description
Add null resources which will trigger identitystore group and user data source refresh. This allows to create SSO users and groups in the same state file as `terraform-aws-sso` module resources and without adding `depends_on` argument at the module level. (check `with_dependencies` example). When using `null` resource instead of `depends_on`, it will only recreate account assignments, when aa new SSO group is added. It will NOT re-create all module resources, after a new AWS Account is added. 

## Breaking Changes
When updating the module version, it will re-create all account assignments on the first terraform apply as it creates null_resources, so can disconnect the sessions and require re-authentication. 

## Testing
Tested manually.